### PR TITLE
Defining body in the blog collection

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -13,3 +13,4 @@ collections:
       - { name: path, label: Path }
       - { name: date, label: Date, widget: date }
       - { name: title, label: Title }
+      - { name: body, label: Body, widget: markdown }


### PR DESCRIPTION
…, so the html attribute of markdownRemark is editable.

I had trouble figuring this out, as the only time it's mentioned is in [In files with frontmatter, one field should be named body. This special field represents the section of the document (usually markdown) that comes after the frontmatter.](https://www.netlifycms.org/docs/configuration-options/#fields)